### PR TITLE
feat: Add order creation endpoint for customer checkout from cart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'devise-jwt'
 # Authorization
 gem 'petergate'
 gem 'kaminari'
+gem 'sidekiq'
 
 # CORS (for frontend/API access)
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,8 @@ GEM
     rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
+    redis-client (0.25.0)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -292,6 +294,12 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -335,6 +343,7 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.1)
   rspec-rails
   rubocop-rails-omakase
+  sidekiq
   tzinfo-data
   warden-jwt_auth
 

--- a/app/controllers/api/v1/customer/orders_controller.rb
+++ b/app/controllers/api/v1/customer/orders_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::Customer::OrdersController < Api::V1::BaseController
+    before_action :authorize_customer!
+
+    def create
+        Orders::ProcessOrderJob.perform_later(@current_user.id)
+        render json: { message: "Order is being processed!" }, status: :accepted
+    end
+
+    def authorize_customer!
+        Rails.logger.debug "💬 role = #{@current_user&.role.inspect}"
+        unless @current_user&.role == :customer
+            render json: { error: 'You need to login to use Cart' }, status: :forbidden
+        end
+    end
+end

--- a/app/jobs/orders/process_order_job.rb
+++ b/app/jobs/orders/process_order_job.rb
@@ -1,0 +1,35 @@
+class Orders::ProcessOrderJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id)
+    user = User.find(user_id)
+    cart = user.cart
+    return if cart.blank? || cart.cart_items.blank?
+
+    ActiveRecord::Base.transaction do
+      order = user.orders.create!(
+        total_price: cart.cart_items.sum { |item| item.quantity * item.product.price },
+        status: :placed
+      )
+
+      cart.cart_items.includes(:product).each do |cart_item|
+        product = cart_item.product
+        quantity = cart_item.quantity
+
+        if product.stock >= quantity
+          product.update!(stock: product.stock - quantity)
+
+          order.order_items.create!(
+            product_id: product.id,
+            quantity: quantity,
+            price: product.price
+          )
+        else
+          raise "Insufficient stock for #{product.title}"
+        end
+      end
+
+      cart.cart_items.destroy_all
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,15 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :order_items, dependent: :destroy
+  enum :status, {
+    placed: "placed",
+    processed: "processed",
+    shipped: "shipped",
+    in_transit: "in_transit",
+    delivered: "delivered",
+    cancelled: "cancelled"
+  }
+
+  validates :status, presence: true, inclusion: { in: statuses.keys }
+  validates :total_price, presence: true, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,6 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+
+  validates :quantity, :price, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ petergate roles: [:admin, :seller, :customer], multiple: false
 
   has_many :products, dependent: :destroy
   has_one :cart, dependent: :destroy
-
+  has_many :orders, dependent: :destroy
   after_initialize :set_default_role, if: :new_record?
   private
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,7 @@ module EcommerceApi
     config.api_only = true
     # config.middleware.use ActionDispatch::Cookies
     # config.middleware.use ActionDispatch::Session::CookieStore
+   
 
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+    config.redis = { url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/1' } }
+end
+
+Sidekiq.configure_client do |config|
+    config.redis = { url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/1' } }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+
+  require 'sidekiq/web'
+  mount Sidekiq::Web => '/sidekiq'
+
   namespace :api do
     namespace :v1 do
       
@@ -30,6 +34,8 @@ Rails.application.routes.draw do
             delete :clear, on: :collection
           end
           resources :cart_items, only: [:create, :update, :destroy]
+
+          resources :orders, only: [:create, :index, :show]
         end
     end
   end

--- a/db/migrate/20250630135501_create_orders.rb
+++ b/db/migrate/20250630135501_create_orders.rb
@@ -1,0 +1,11 @@
+class CreateOrders < ActiveRecord::Migration[7.2]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.decimal :total_price
+      t.string :status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250630135502_create_order_items.rb
+++ b/db/migrate/20250630135502_create_order_items.rb
@@ -1,0 +1,12 @@
+class CreateOrderItems < ActiveRecord::Migration[7.2]
+  def change
+    create_table :order_items do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+      t.integer :quantity
+      t.decimal :price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_24_135322) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_30_135502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_24_135322) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.integer "quantity"
+    t.decimal "price"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.decimal "total_price"
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -67,6 +87,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_24_135322) do
   add_foreign_key "cart_items", "carts"
   add_foreign_key "cart_items", "products"
   add_foreign_key "carts", "users"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "users"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "users"
 end

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :order_item do
+    order { nil }
+    product { nil }
+    quantity { 1 }
+    price { "9.99" }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order do
+    user { nil }
+    total_price { "9.99" }
+    status { "MyString" }
+  end
+end

--- a/spec/jobs/orders/process_order_job_spec.rb
+++ b/spec/jobs/orders/process_order_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Orders::ProcessOrderJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/customer/orders_spec.rb
+++ b/spec/requests/api/v1/customer/orders_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Customer::Orders", type: :job do
+  let(:customer) { create(:user, role: 'customer') }
+  let(:seller) { create(:user, role: 'seller') }
+  let(:category) { create(:category) }
+  let(:product) { create(:product, user: seller, category: category, stock: 10, price: 100) }
+
+  before do
+    cart = customer.create_cart
+    cart.cart_items.create(product: product, quantity: 2)
+  end
+
+  it "creates an order and reduces stock after successful checkout" do
+    expect {
+      Orders::ProcessOrderJob.perform_now(customer.id)
+    }.to change { Order.count }.by(1)
+     .and change { OrderItem.count }.by(1)
+     .and change { product.reload.stock }.from(10).to(8)
+
+    order = customer.orders.last
+    expect(order.total_price).to eq(200)
+    expect(order.status).to eq("placed")
+  end
+
+  it "does not create an order if stock is insufficient" do
+    product.update(stock: 1)
+
+    expect {
+      expect {
+        Orders::ProcessOrderJob.perform_now(customer.id)
+      }.to raise_error(RuntimeError, /Insufficient stock/)
+    }.to_not change { Order.count }
+
+    expect(product.reload.stock).to eq(1)
+  end
+
+  it "clears the cart after checkout" do
+    puts "Cart items before: #{customer.cart.cart_items.count}"
+    Orders::ProcessOrderJob.perform_now(customer.id)
+    puts "Cart items after: #{customer.reload.cart.cart_items.count}"
+    expect(customer.cart.cart_items).to be_empty
+  end
+end


### PR DESCRIPTION
✅ Features Implemented

**Order Creation Endpoint**

- Adds POST /api/v1/customer/orders
- Triggers Orders::ProcessOrderJob to process the order in the background
- Accepts no params — uses the current customer's cart

**ProcessOrderJob**

- Creates a new Order with associated OrderItems from the customer’s cart
- Captures quantity and price snapshot for each product
- Deducts stock from products based on quantity
- Clears the cart after successful order placement
- Raises error if stock is insufficient for any item

**🔐 Access Control**

- Endpoint restricted to users with customer role via Devise + JWT
- Ensures customers can only place orders from their own cart

**🧪 Tests**

- Verified:

  - Successful order creation and stock deduction
  - Cart is emptied after order is placed
  - Order not created if stock is insufficient

- All tests pass using RSpec

**🛠️ Tech**

- Uses ActiveJob with Sidekiq as background queue adapter
- Redis is required to process the job