### PR TITLE
Feature: Add product search service with keyword

### DIFF
--- a/app/controllers/api/v1/public/products_controller.rb
+++ b/app/controllers/api/v1/public/products_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Public::ProductsController < ApplicationController
   def index
-    @products = Product.page(params[:page]).per(params[:per_page] || 10)
+    @products = Product::Searching.new(params).call
 
     if @products.any?
       render json: {

--- a/app/services/product/searching.rb
+++ b/app/services/product/searching.rb
@@ -1,0 +1,15 @@
+class Product::Searching
+    def initialize(params = {})
+        @query = params[:search].to_s.strip
+        @page = (params[:page] || 1).to_i
+        @per_page = (params[:per_page] || 10).to_i
+    end
+
+    def call
+        products = Product.left_joins(:category)
+        if @query.present?
+            products = products.where("products.title ILIKE :q OR products.description ILIKE :q OR categories.name ILIKE :q", q: "%#{@query}%")
+        end
+        products.page(@page).per(@per_page)
+    end
+end


### PR DESCRIPTION
#  Feature: Add product search service with keyword

## Summary

This PR introduces the first implementation of product search functionality.

## Why This Change

Previously, there was no way to search products by keyword or category. This change enables users to find products more easily and improves the API’s usability.

## Changes Made

- Added `Product::Searching` service object.
- Supports searching by product title, description, or category name (case-insensitive).
- Includes pagination with `page` and `per_page` parameters.
- Updated the public products controller to use the new service.

## Example Usage

- `GET /api/v1/public/products?search=shoes&page=1&per_page=10`

## Impact

- Adds essential search capability to the product catalog.
- Lays the foundation for future enhancements (e.g., more filters, sorting).